### PR TITLE
Cell type proposal

### DIFF
--- a/Datagrid/Cell/Cell.php
+++ b/Datagrid/Cell/Cell.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Opifer\CrudBundle\Datagrid\Row;
+namespace Opifer\CrudBundle\Datagrid\Cell;
 
 /**
  * Cell
@@ -16,11 +16,13 @@ class Cell
     protected $type;
 
     /** @var string */
+    protected $view;
+
+    /** @var string */
     protected $value;
 
     /** @var Array */
     protected $attributes;
-
 
     /**
      * Set property
@@ -67,6 +69,28 @@ class Cell
     }
 
     /**
+     * Set view
+     *
+     * @param string $view
+     */
+    public function setView($view)
+    {
+        $this->view = $view;
+
+        return $this;
+    }
+
+    /**
+     * Get view
+     *
+     * @return string
+     */
+    public function getView()
+    {
+        return $this->view;
+    }
+
+    /**
      * Set value
      *
      * @param string $value
@@ -93,7 +117,7 @@ class Cell
      *
      * @param \Closure $attributes
      */
-    public function setAttributes(array $attributes)
+    public function setAttributes(array $attributes = [])
     {
         $this->attributes = $attributes;
 

--- a/Datagrid/Cell/CellFactory.php
+++ b/Datagrid/Cell/CellFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell;
+
+use Opifer\CrudBundle\Datagrid\Column\Column;
+use Opifer\CrudBundle\Datagrid\Cell\Type\CellTypeInterface;
+use Opifer\CrudBundle\Datagrid\Row\Row;
+
+class CellFactory
+{
+    /**
+     * Create a cell
+     *
+     * @param  Column $column
+     * @param  object $row
+     *
+     * @return Cell
+     */
+    public function create(Column $column, $row)
+    {
+        $cellType = $column->getCellType();
+
+        $cell = new Cell();
+        $cell->setValue($cellType->getData($row, $column));
+        $cell->setType($cellType->getName());
+        $cell->setView($cellType->getView());
+        if (null !== $column->getAttributes()) {
+            $cell->setAttributes($column->getAttributes());
+        }
+        $cell->setProperty($column->getProperty());
+
+        return $cell;
+    }
+}

--- a/Datagrid/Cell/Type/CellTypeInterface.php
+++ b/Datagrid/Cell/Type/CellTypeInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell\Type;
+
+use Opifer\CrudBundle\Datagrid\Column\Column;
+
+interface CellTypeInterface
+{
+    /**
+     * Get the cell data
+     *
+     * @param  mixed  $row
+     * @param  Column $column
+     *
+     * @return mixed
+     */
+    public function getData($row, Column $column);
+
+    /**
+     * Get the view name
+     *
+     * @return string
+     */
+    public function getView();
+
+    /**
+     * The type name
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/Datagrid/Cell/Type/CheckboxCell.php
+++ b/Datagrid/Cell/Type/CheckboxCell.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell\Type;
+
+class CheckboxCell extends PropertyCell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getView()
+    {
+        return 'checkbox';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'checkbox';
+    }
+}

--- a/Datagrid/Cell/Type/DateTimeCell.php
+++ b/Datagrid/Cell/Type/DateTimeCell.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell\Type;
+
+use Opifer\CrudBundle\Datagrid\Column\Column;
+
+class DateTimeCell extends PropertyCell
+{
+    protected $format;
+
+    public function __construct($format = 'd-m-Y')
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getData($row, Column $column)
+    {
+        $value = parent::getData($row, $column);
+
+        return $value->format($this->format);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getView()
+    {
+        return 'text';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'datetime';
+    }
+}

--- a/Datagrid/Cell/Type/LabelCell.php
+++ b/Datagrid/Cell/Type/LabelCell.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell\Type;
+
+use Opifer\CrudBundle\Datagrid\Column\Column;
+
+class LabelCell extends PropertyCell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getData($row, Column $column)
+    {
+        $value = parent::getData($row, $column);
+
+        return ($value == 1) ? 'Yes' : 'No';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getView()
+    {
+        return 'label';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'label';
+    }
+}

--- a/Datagrid/Cell/Type/PropertyCell.php
+++ b/Datagrid/Cell/Type/PropertyCell.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Opifer\CrudBundle\Datagrid\Cell\Type;
+
+use Opifer\CrudBundle\Datagrid\Column\Column;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class PropertyCell implements CellTypeInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getData($row, Column $column)
+    {
+        $accessor = PropertyAccess::getPropertyAccessor();
+
+        return $accessor->getValue($row, $column->getProperty());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getView()
+    {
+        return 'text';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'property';
+    }
+}

--- a/Datagrid/Column/Column.php
+++ b/Datagrid/Column/Column.php
@@ -2,6 +2,8 @@
 
 namespace Opifer\CrudBundle\Datagrid\Column;
 
+use Opifer\CrudBundle\Datagrid\Cell\Type\CellTypeInterface;
+
 /**
  * Column
  *
@@ -15,8 +17,8 @@ class Column
     /** @var label */
     protected $label;
 
-    /** @var type */
-    protected $type;
+    /** @var cellType */
+    protected $cellType;
 
     /** @var \Closure */
     protected $closure;
@@ -69,25 +71,25 @@ class Column
     }
 
     /**
-     * Set type
+     * Set cellType
      *
-     * @param string $type
+     * @param string $cellType
      */
-    public function setType($type)
+    public function setCellType(CellTypeInterface $cellType)
     {
-        $this->type = $type;
+        $this->cellType = $cellType;
 
         return $this;
     }
 
     /**
-     * Get type
+     * Get cellType
      *
      * @return string
      */
-    public function getType()
+    public function getCellType()
     {
-        return $this->type;
+        return $this->cellType;
     }
 
     /**
@@ -117,7 +119,7 @@ class Column
      *
      * @param \Closure $attributes
      */
-    public function setAttributes(array $attributes)
+    public function setAttributes(array $attributes = [])
     {
         $this->attributes = $attributes;
 

--- a/Datagrid/DatagridBuilder.php
+++ b/Datagrid/DatagridBuilder.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use Opifer\CrudBundle\Datagrid\Column\Column;
+use Opifer\CrudBundle\Datagrid\Cell\Type\CellTypeInterface;
 use Opifer\CrudBundle\Entity\ListView;
 use Opifer\CrudBundle\Pagination\Paginator;
 
@@ -51,11 +52,11 @@ class DatagridBuilder implements DatagridBuilderInterface
     /**
      * {@inheritDoc}
      */
-    public function addColumn($property, $type = 'text', array $options = array())
+    public function addColumn($property, CellTypeInterface $cell, array $options = array())
     {
         $column = new Column();
         $column->setProperty($property);
-        $column->setType($type);
+        $column->setCellType($cell);
 
         if (isset($options['attr'])) {
             $column->setAttributes($options['attr']);

--- a/Datagrid/DatagridBuilderInterface.php
+++ b/Datagrid/DatagridBuilderInterface.php
@@ -2,6 +2,8 @@
 
 namespace Opifer\CrudBundle\Datagrid;
 
+use Opifer\CrudBundle\Datagrid\Cell\Type\CellTypeInterface;
+
 interface DatagridBuilderInterface
 {
     /**
@@ -20,7 +22,7 @@ interface DatagridBuilderInterface
      * @param string $type
      * @param array  $options
      */
-    public function addColumn($property, $type = 'text', array $options = []);
+    public function addColumn($property, CellTypeInterface $cell, array $options = []);
 
     /**
      * Adds a where clause

--- a/Datagrid/DatagridMapper.php
+++ b/Datagrid/DatagridMapper.php
@@ -239,50 +239,51 @@ class DatagridMapper
             $row->setName($originalRow->getId());
 
             foreach ($columns as $column) {
-                $cell = new Cell();
+                $cellFactory = new \Opifer\CrudBundle\Datagrid\Cell\CellFactory();
+                $cell = $cellFactory->create($column, $originalRow);
+                $row->addCell($cell);
+                //$cell = new Cell();
 
                 // Set a row name value
-                if (in_array($column->getProperty(), ['username', 'name', 'title'])) {
-                    $row->setName($accessor->getValue($originalRow, $column->getProperty()));
-                }
+                // if (in_array($column->getProperty(), ['username', 'name', 'title'])) {
+                //     $row->setName($accessor->getValue($originalRow, $column->getProperty()));
+                // }
 
-                // Handle the raw value
-                if ($column->getClosure() instanceof \Closure) {
-                    $closure = $column->getClosure();
-                    $value = $accessor->getValue($originalRow, $column->getProperty());
-                    $value = $closure($value);
-                } elseif ($column->getType() == 'count') {
-                    // in case of one-to-many or many-to-many relations, show
-                    // the count of related rows
-                    $getter = 'get' . ucfirst($column->getProperty());
-                    $value = $originalRow->$getter()->count();
-                } else {
-                    try {
-                        $value = $accessor->getValue($originalRow, $column->getProperty());
-                    } catch (\Exception $e) {
-                        $value = null;
-                    }
-                }
+                // // Handle the raw value
+                // if ($column->getClosure() instanceof \Closure) {
+                //     $closure = $column->getClosure();
+                //     $value = $accessor->getValue($originalRow, $column->getProperty());
+                //     $value = $closure($value);
+                // } elseif ($column->getType() == 'count') {
+                //     // in case of one-to-many or many-to-many relations, show
+                //     // the count of related rows
+                //     $getter = 'get' . ucfirst($column->getProperty());
+                //     $value = $originalRow->$getter()->count();
+                // } else {
+                //     try {
+                //         $value = $accessor->getValue($originalRow, $column->getProperty());
+                //     } catch (\Exception $e) {
+                //         $value = null;
+                //     }
+                // }
 
-                // Handle the generated value
-                if ($value instanceof \DateTime) {
-                    $value = $value->format('d-m-Y');
-                } elseif (is_array($value)) {
-                    $value = json_encode($value);
-                }
+                // // Handle the generated value
+                // if ($value instanceof \DateTime) {
+                //     $value = $value->format('d-m-Y');
+                // } elseif (is_array($value)) {
+                //     $value = json_encode($value);
+                // }
 
-                if (null !== $column->getType()) {
-                    $cell->setType($column->getType());
-                }
+                // if (null !== $column->getType()) {
+                //     $cell->setType($column->getType());
+                // }
 
-                $cell->setValue($value);
-                $cell->setProperty($column->getProperty());
+                // $cell->setValue($value);
+                // $cell->setProperty($column->getProperty());
                 
-                if ($column->getAttributes()) {
-                    $cell->setAttributes($column->getAttributes());
-                }
-
-                $row->addCell($cell);
+                // if ($column->getAttributes()) {
+                //     $cell->setAttributes($column->getAttributes());
+                // }
             }
 
             $row->setId($originalRow->getId());

--- a/Datagrid/Row/Row.php
+++ b/Datagrid/Row/Row.php
@@ -3,6 +3,7 @@
 namespace Opifer\CrudBundle\Datagrid\Row;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Opifer\CrudBundle\Datagrid\Cell\Cell;
 
 /**
  * Row

--- a/Datagrid/ViewBuilder.php
+++ b/Datagrid/ViewBuilder.php
@@ -29,19 +29,17 @@ class ViewBuilder
     }
 
     /**
-     * [build description]
+     * Get row query
+     * 
      * @param  Opifer\RulesEngine\Condition $conditions
      * @param  string                       $entity
-     * @return [type]
+     * 
+     * @return QueryBuilder
      */
     public function getRowQuery($conditions, $entity)
     {
-        // waarom passen we condities niet gewoon op een repository toe? maak
-        // de repository dat ie implements environment met de get operator en de
-        // condities kunnen door middel van evaluate() rechtstreeks de Env aanpassen
-
-        $repo = $this->em->getRepository(get_class($entity));
-        $qb = $repo->createQueryBuilder('a'); // use exotic alias because we use entity's own repository
+        $qb = $this->em->getRepository(get_class($entity))
+            ->createQueryBuilder('a'); // use exotic alias because we use entity's own repository
 
         $environment = new DoctrineEnvironment();
         $environment->queryBuilder = $qb;
@@ -51,7 +49,10 @@ class ViewBuilder
     }
 
     /**
+     * 
+     * 
      * @param  array $items
+     * 
      * @return array
      */
     public function wheres($items)

--- a/Resources/views/Datagrid/table.html.twig
+++ b/Resources/views/Datagrid/table.html.twig
@@ -16,11 +16,7 @@
             <tr>
                 {#<td><input type="checkbox" name="item[]" value="{{ row.id }}" /></td>#}
                 {% for data in row.cells %}
-                    {% if data['options']['template'] is defined %}
-                        {{ include(data['options']['template']) }}
-                    {% else %}
-                        {{ include('OpiferCrudBundle:Datagrid:td.html.twig') }}
-                    {% endif %}
+                    {{ include('OpiferCrudBundle:Datagrid:td.html.twig') }}
                 {% endfor %}
                 {% if grid.options['actions'] is defined %}
                     <td class="actions">

--- a/Resources/views/Datagrid/td.html.twig
+++ b/Resources/views/Datagrid/td.html.twig
@@ -1,5 +1,5 @@
 {% use 'OpiferCrudBundle:Datagrid:cells.html.twig' %}
 
 {% if data is not null %}
-    {{ block(data.type ~ '_cell') }}
+    {{ block(data.view ~ '_cell') }}
 {% endif %}


### PR DESCRIPTION
@dylanschoenmakers ,

A first proposal of how we could implement Cell types.

An example of the way this works in a Grid:

``` php
public function buildGrid(DatagridBuilderInterface $builder)
{
    $builder
        ->addColumn('enabled', new LabelCell(), ['label' => 'Activated'])
        ->addColumn('username', new PropertyCell(), ['label' => 'User name'])
        ->addColumn('email', new PropertyCell(), ['label' => 'Email address'])
        ->addColumn('createdAt', new DateTimeCell(), ['label' => 'Created'])
    ;
}
```

Where `PropertyCell` is a base cell (not abstract in this case, but we could change it to abstract).
Its `getData` method uses Symfony's [PropertyAccess](http://symfony.com/doc/current/components/property_access/introduction.html) component that works with `arrays`, `getters`, `issers`, `hassers`.
